### PR TITLE
Add a test to ensure module can be used

### DIFF
--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -1,0 +1,8 @@
+use v6;
+use Test;
+
+plan 1;
+
+use-ok 'Net::XMPP';
+
+# vim: expandtab shiftwidth=4 ft=perl6


### PR DESCRIPTION
This test ensures that, at the very least, the module can be used and thus loaded correctly.  It also highlights that the module uses a deprecated syntax feature, which will be corrected in a following PR.
