### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Net/XMPP.pm6
+++ b/lib/Net/XMPP.pm6
@@ -1,4 +1,4 @@
-class Net::XMPP;
+unit class Net::XMPP;
 
 use Net::XMPP::IQ;
 use Net::XMPP::Presence;

--- a/lib/Net/XMPP/IQ.pm6
+++ b/lib/Net/XMPP/IQ.pm6
@@ -1,4 +1,4 @@
-class Net::XMPP::IQ;
+unit class Net::XMPP::IQ;
 
 has $.from = '';
 has $.to = '';

--- a/lib/Net/XMPP/Message.pm6
+++ b/lib/Net/XMPP/Message.pm6
@@ -1,4 +1,4 @@
-class Net::XMPP::Message;
+unit class Net::XMPP::Message;
 
 has $.from = '';
 has $.to = '';

--- a/lib/Net/XMPP/Presence.pm6
+++ b/lib/Net/XMPP/Presence.pm6
@@ -1,4 +1,4 @@
-class Net::XMPP::Presence;
+unit class Net::XMPP::Presence;
 
 has $.from = '';
 has $.to = '';


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.
